### PR TITLE
MS switched the character used for the function icon -- this switches…

### DIFF
--- a/theme/blockly-core.less
+++ b/theme/blockly-core.less
@@ -229,7 +229,7 @@ span.blocklyTreeIcon {
     font-family: xicon !important;
 }
 .blocklyTreeIcon.blocklyTreeIconfunctions::before {
-    content: "\f109";
+    content: "\f107";
     vertical-align: middle;
 }
 .blocklyFlyoutLabelIcon.blocklyFlyoutIconfunctions {


### PR DESCRIPTION
… it back to the old character that we used in our fonts.