### PR TITLE
Microsoft logo is missing #302

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -660,6 +660,7 @@ p.ui.font.small {
 /* Large Monitor */
 @media only screen and (min-width: @largeMonitorBreakpoint) {
     #editorlogo > .poweredbylogo {
+        .includePoweredByLogos(); // set the @poweredByLarge variable
         background-image: @poweredByLarge;
     }
 }
@@ -667,6 +668,7 @@ p.ui.font.small {
 /* Small Monitor */
 @media only screen and (min-width: @computerBreakpoint) and (max-width: @largestSmallMonitor) {
     #editorlogo > .poweredbylogo {
+        .includePoweredByLogos(); // set the @poweredByLarge variable
         background-image: @poweredByLarge;
     }
 }
@@ -679,6 +681,7 @@ p.ui.font.small {
     #editorlogo > .poweredbylogo {
         height: 12px;
         bottom: 3px;
+        .includePoweredByLogos(); // set the @poweredBySmall variable
         background-image: @poweredBySmall;
     }
 }
@@ -691,6 +694,7 @@ p.ui.font.small {
     #editorlogo > .poweredbylogo {
         height: 13px;
         bottom: 3px;
+        .includePoweredByLogos(); // set the @poweredBySmall variable
         background-image: @poweredBySmall;
     }
 }


### PR DESCRIPTION
Microsoft logo is missing #302
WW Jira Tracking: ANA-3209 [Chromebook][Win10] Microsoft logo is missing from Code editor 

Root Cause:
Microsoft made a change to only show the 'Powered by Microsoft' logo when a certain variable is set. (https://github.com/Microsoft/pxt/commit/65b83939241a07b3a836a355e9dd61033b9cfc28#diff-9cebd1b4c653e57f52e3047257bc1adf) 

However, in the  'poweredbylogo' .less classes that adjust the logo for various media, the @poweredBySmall and @poweredByLarge variables that set the background-image links are still set to be 'none'. To set these variables to actual urls based on the 'includePoweredByLogos' value, we need to call the .includePoweredByLogos() in each style block.

(FYI. I tried having the .includePoweredByLogos() outside of each specific poweredbylogo class,  calling that function immediately after defining it in pxt code site.variables file, and calling that function after copying all those variables + function to the pxt-wonder version of site.variables. None of those places will set the variables so the background-image url is actually valid (they are always 'none'). 
The only place where calling the .includePoweredByLogos() function properly sets the variables is in each #editorlogo > .poweredbylogo class. )